### PR TITLE
Add richer Kendrick context and retrieval

### DIFF
--- a/server/interpretations.ts
+++ b/server/interpretations.ts
@@ -1,0 +1,24 @@
+export interface KnownInterpretation {
+  lyricSnippet: string;
+  explanation: string;
+}
+
+export const knownInterpretations: KnownInterpretation[] = [
+  {
+    lyricSnippet: "loyalty, got royalty inside my DNA",
+    explanation: "In 'DNA.' Kendrick boasts about his innate qualities and heritage, emphasizing pride in his roots and personal code."
+  },
+  {
+    lyricSnippet: "we gon' be alright",
+    explanation: "The chorus of 'Alright' became an anthem for resilience and hope in the face of racial injustice."
+  }
+];
+
+export function getContextForLyric(lyric: string): string | undefined {
+  for (const item of knownInterpretations) {
+    if (lyric.toLowerCase().includes(item.lyricSnippet.toLowerCase())) {
+      return item.explanation;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- extend the system prompt in `interpretLyric` with more details about Kendrick Lamar's recurring themes and personas
- add small knowledge base of lyric snippets for retrieval
- incorporate retrieved context into the user message sent to OpenAI

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_683fc54b6dac8322a07172a6ef6fca9f